### PR TITLE
fix(db): improve network / machine crash tolerance for replication

### DIFF
--- a/db/51-server.cnf.var
+++ b/db/51-server.cnf.var
@@ -4,3 +4,5 @@ wait_timeout = 28800
 server-id = 2${DESECSLAVE_ID}
 binlog_format=ROW
 log-basename=${DESECSTACK_DBMASTER_USERNAME_replication}
+innodb_flush_log_at_trx_commit=1
+sync_binlog=1


### PR DESCRIPTION
We have been having some problems with slaves rebooting (after kernel update) without shutting down replication properly. Sometimes, this lead to problems when resuming replication (binlog on slave was corrupted; last happened on Oct 3 at the lax-1.a.desec.io). This should solve this sort of problem.