### PR TITLE
BREAKING feat(db): change recommended value of DESECSLAVE_ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Although most configuration is contained in this repository, some external depen
     - certificates
       - `DESECSLAVE_CERT_FOLDER`: `./path/` to slave TLS key (`key.pem`), slave certificate (`crt.pem`), and CA certificate (`ca.pem`).
     - ns-related
-      - `DESECSLAVE_ID`: MySQL replication slave `server-id` (must be unique across replication topology)
+      - `DESECSLAVE_ID`: MySQL replication slave `server-id` (must be unique across replication topology!). As this is a 32-bit value, a good value is the integer representation of the host's IPv4 unicast address (given that it is unique). Assuming that the hostname is configured correctly in the DNS, this can easily be obtained by `IFS=. read -r a b c d <<< $(dig A +short $(hostname)); echo $((a * 256 ** 3 + b * 256 ** 2 + c * 256 + d))`.
       - `DESECSLAVE_DB_PASSWORD_pdns`: mysql password for pdns on ns
       - `DESECSLAVE_CARBONSERVER`: pdns `carbon-server` setting (optional)
       - `DESECSLAVE_CARBONOURNAME`: pdns `carbon-ourname` setting (optional)

--- a/db/51-server.cnf.var
+++ b/db/51-server.cnf.var
@@ -1,7 +1,7 @@
 [mysqld]
 wait_timeout = 28800
 
-server-id = 2${DESECSLAVE_ID}
+server-id = ${DESECSLAVE_ID}
 binlog_format=ROW
 log-basename=${DESECSTACK_DBMASTER_USERNAME_replication}
 innodb_flush_log_at_trx_commit=1


### PR DESCRIPTION
For details see commit message.

For our deployment, this is actually not a breaking change (there will be no collisions if we don't update the configuration), but we should still follow the new recommendation.