### PR TITLE
20200208 prometheus

### DIFF
--- a/dnsdist/Dockerfile
+++ b/dnsdist/Dockerfile
@@ -6,7 +6,7 @@ RUN set -ex \
 	&& apt-get update \
 	&& apt-get install -y curl gnupg
 
-RUN echo 'deb [arch=amd64] http://repo.powerdns.com/debian stretch-dnsdist-13 main' \
+RUN echo 'deb [arch=amd64] http://repo.powerdns.com/debian stretch-dnsdist-14 main' \
       >> /etc/apt/sources.list \
  && echo 'Package: dnsdist*' \
       > /etc/apt/preferences.d/dnsdist \

--- a/dnsdist/conf/dnsdist.conf
+++ b/dnsdist/conf/dnsdist.conf
@@ -16,6 +16,6 @@ setVerboseHealthChecks(true)
 newServer("10.16.2.2")
 
 -- do not expose zones under .internal, especially catalog.internal
-addAction("internal.", RCodeAction(dnsdist.REFUSED))
+addAction("internal.", RCodeAction(DNSRCode.REFUSED))
 
 -- TOOD add webserver here for Prometheus monitoring

--- a/dnsdist/conf/dnsdist.conf
+++ b/dnsdist/conf/dnsdist.conf
@@ -18,4 +18,7 @@ newServer("10.16.2.2")
 -- do not expose zones under .internal, especially catalog.internal
 addAction("internal.", RCodeAction(DNSRCode.REFUSED))
 
--- TOOD add webserver here for Prometheus monitoring
+-- web server for metrics scraping
+--  See https://github.com/PowerDNS/pdns/issues/8797#issuecomment-584056727
+--  for why a password is used instead of an API key.
+webserver("10.16.4.10:8083", "we+ensure+security+via+network+segmentation", "")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,6 +58,7 @@ services:
     - DESECSTACK_VPN_SERVER
     volumes:
     - ./openvpn-client/secrets:/etc/openvpn/secrets:ro
+    - openvpn-client_logs:/var/log/openvpn
     networks:
       rearreplication:
         ipv4_address: 10.16.3.2
@@ -65,6 +66,22 @@ services:
       driver: "syslog"
       options:
         tag: "desec-slave/openvpn-client"
+    restart: unless-stopped
+
+  openvpn-client_monitor:
+    image: kumina/openvpn-exporter:v0.2.2
+    init: true
+    depends_on:
+    - openvpn-client
+    volumes:
+    - openvpn-client_logs:/var/log/openvpn:ro
+    networks:
+    - rearmonitoring_openvpn-client
+    command: -openvpn.status_paths /var/log/openvpn/openvpn-status.log
+    logging:
+      driver: "syslog"
+      options:
+        tag: "desec-slave/openvpn-client_monitor"
     restart: unless-stopped
 
   replicator:
@@ -96,6 +113,8 @@ services:
     volumes:
     - ./prometheus/conf:/etc/prometheus:ro
     - prometheus:/prometheus
+    networks:
+      rearmonitoring_openvpn-client:
     logging:
       driver: "syslog"
       options:
@@ -105,6 +124,7 @@ services:
 volumes:
   ns:
   prometheus:
+  openvpn-client_logs:
 
 networks:
   # Note that it is required that the front network ranks lower (in lexical order by
@@ -139,3 +159,10 @@ networks:
       config:
       - subnet: 10.16.3.0/24
         gateway: 10.16.3.1
+  rearmonitoring_openvpn-client:
+      driver: bridge
+      ipam:
+        driver: default
+        config:
+        - subnet: 10.16.4.0/29
+          gateway: 10.16.4.1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,8 +88,23 @@ services:
         tag: "desec-slave/replicator"
     restart: unless-stopped
 
+  prometheus:
+    image: prom/prometheus:latest
+    init: true
+    ports:
+    - "127.0.0.1:9090:9090"
+    volumes:
+    - ./prometheus/conf:/etc/prometheus:ro
+    - prometheus:/prometheus
+    logging:
+      driver: "syslog"
+      options:
+        tag: "desec-slave/prometheus"
+    restart: unless-stopped
+
 volumes:
   ns:
+  prometheus:
 
 networks:
   # Note that it is required that the front network ranks lower (in lexical order by

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,6 +42,8 @@ services:
         ipv6_address: ${DESECSLAVE_IPV6_ADDRESS}
       middle:
         ipv4_address: 10.16.2.3
+      rearmonitoring_dnsdist:
+        ipv4_address: 10.16.4.10
     logging:
       driver: "syslog"
       options:
@@ -115,6 +117,8 @@ services:
     - prometheus:/prometheus
     networks:
       rearmonitoring_openvpn-client:
+      rearmonitoring_dnsdist:
+        ipv4_address: 10.16.4.11
     logging:
       driver: "syslog"
       options:
@@ -166,3 +170,10 @@ networks:
         config:
         - subnet: 10.16.4.0/29
           gateway: 10.16.4.1
+  rearmonitoring_dnsdist:
+      driver: bridge
+      ipam:
+        driver: default
+        config:
+        - subnet: 10.16.4.8/29
+          gateway: 10.16.4.9

--- a/openvpn-client/conf/client.conf.var
+++ b/openvpn-client/conf/client.conf.var
@@ -123,6 +123,10 @@ auth SHA256
 # enabled in the server config file.
 #comp-lzo
 
+# Write status information regularly
+status /var/log/openvpn/openvpn-status.log 15
+status-version 3
+
 # Set log file verbosity.
 verb 3
 

--- a/prometheus/conf/prometheus.yml
+++ b/prometheus/conf/prometheus.yml
@@ -12,3 +12,6 @@ scrape_configs:
   - job_name: 'prometheus'
     static_configs:
       - targets: ['localhost:9090']
+  - job_name: 'openvpn-client'
+    static_configs:
+      - targets: ['openvpn-client_monitor:9176']

--- a/prometheus/conf/prometheus.yml
+++ b/prometheus/conf/prometheus.yml
@@ -15,3 +15,9 @@ scrape_configs:
   - job_name: 'openvpn-client'
     static_configs:
       - targets: ['openvpn-client_monitor:9176']
+  - job_name: 'dnsdist'
+    static_configs:
+      - targets: ['dnsdist:8083']
+    basic_auth:
+      username: arbitrary
+      password: we+ensure+security+via+network+segmentation

--- a/prometheus/conf/prometheus.yml
+++ b/prometheus/conf/prometheus.yml
@@ -1,0 +1,14 @@
+global:
+  scrape_interval:     15s # By default, scrape targets every 15 seconds.
+
+  # Attach these labels to any time series or alerts when communicating with
+  # external systems (federation, remote storage, Alertmanager).
+  external_labels:
+    monitor: 'desec-slave'
+
+# A scrape configuration containing exactly one endpoint to scrape:
+# Here it's Prometheus itself.
+scrape_configs:
+  - job_name: 'prometheus'
+    static_configs:
+      - targets: ['localhost:9090']


### PR DESCRIPTION
This adds Prometheus monitoring for openvpn-client, dnsdist, and for Prometheus itself.

There is a test deployment (unauthenticated, unencrypted) at http://ns1.sandbox.dedyn.io:9090/. We need to figure out how to secure access. Options:
- Reverse proxy (downside: exposes a port)
- through replication VPN (topologically inappropriate)
- extra VPN
- something else?