### PR TITLE
LMDB dump for faster provisioning

### DIFF
--- a/docker-compose.dump.yml
+++ b/docker-compose.dump.yml
@@ -17,3 +17,12 @@ services:
   prometheus:
     entrypoint: ["echo", "Service disabled"]
     restart: "no"
+
+  lmdb-backup:
+    build: lmdb-backup
+    image: ${DOCKER_REGISTRY}desec/lmdb-backup:latest
+    init: true
+    volumes:
+    - ns:/var/lib/powerdns
+    - ./lmdb-backup/backup:/backup
+    restart: "no"

--- a/docker-compose.dump.yml
+++ b/docker-compose.dump.yml
@@ -1,0 +1,19 @@
+version: '2.2'
+
+# mostly extending from main .yml
+services:
+  dnsdist:
+    entrypoint: ["echo", "Service disabled"]
+    restart: "no"
+
+  openvpn-client_monitor:
+    entrypoint: ["echo", "Service disabled"]
+    restart: "no"
+
+  replicator:
+    environment:
+    - DESECSLAVE_REPLICATOR_EXIT_WHEN_DONE=1
+
+  prometheus:
+    entrypoint: ["echo", "Service disabled"]
+    restart: "no"

--- a/dump.sh
+++ b/dump.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 docker-compose -f docker-compose.yml -f docker-compose.dump.yml up replicator  # exits replicator when done
 docker-compose -f docker-compose.yml -f docker-compose.dump.yml down  # exits other containers as well
+docker-compose -f docker-compose.yml -f docker-compose.dump.yml run lmdb-backup ./dump

--- a/dump.sh
+++ b/dump.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+docker-compose -f docker-compose.yml -f docker-compose.dump.yml up replicator  # exits replicator when done
+docker-compose -f docker-compose.yml -f docker-compose.dump.yml down  # exits other containers as well

--- a/lmdb-backup/Dockerfile
+++ b/lmdb-backup/Dockerfile
@@ -1,0 +1,14 @@
+FROM gcc:9 as builder
+
+WORKDIR /usr/src/app
+COPY ./build-lmdb.sh .
+RUN ./build-lmdb.sh
+
+
+FROM ubuntu:latest
+COPY --from=builder /tmp/stage/usr/local/bin/* /usr/local/bin/
+
+WORKDIR /usr/src/app
+COPY ./dump ./load ./
+
+RUN mkdir /backup /var/lib/powerdns

--- a/lmdb-backup/backup/.gitignore
+++ b/lmdb-backup/backup/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/lmdb-backup/build-lmdb.sh
+++ b/lmdb-backup/build-lmdb.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Fail hard when anything fails
+set -e
+set -o pipefail
+
+# OpenLDAP / lmdb release, and associated checksum
+VERSION=2.4.49
+CHECKSUM=f0caeca122e6f90e6ac5cc8ba36fe9cec13826da
+
+# Fetch source package and verify checksum
+wget https://www.openldap.org/software/download/OpenLDAP/openldap-release/openldap-${VERSION}.tgz && sha1sum -c <<< "$CHECKSUM openldap-${VERSION}.tgz"
+
+tar xzf openldap-${VERSION}.tgz
+cd openldap-${VERSION}/libraries/liblmdb/
+make && make DESTDIR=/tmp/stage install

--- a/lmdb-backup/dump
+++ b/lmdb-backup/dump
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Fail hard when anything fails
+set -e
+set -o pipefail
+
+# use regexp in filename globbing
+shopt -s extglob  
+
+TARGET_FILE=$(date +%Y%m%d:%H%M%S)_dump.tar.gz
+
+umask 0066
+
+echo Dumping ...
+cd /var/lib/powerdns
+for file in pdns.lmdb pdns.lmdb-+([0-9]); do echo $file; mdb_dump -f /tmp/$file.dump -n -a $file; done
+
+echo Zipping ...
+cd /tmp
+tar czf /backup/${TARGET_FILE} *.dump
+
+echo Done.
+du -h /backup/${TARGET_FILE}

--- a/lmdb-backup/load
+++ b/lmdb-backup/load
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Fail hard when anything fails
+set -e
+set -o pipefail
+
+[[ ! -z "$1" ]] || { echo 'Backup filename must be passed as first argument, aborting.'; exit 1; }
+FILENAME="/backup/$1"
+
+[[ -z "$(ls -A /var/lib/powerdns/)" ]] || { echo '/var/lib/powerdns is not empty, aborting.'; exit 2; }
+
+umask 0066
+
+echo Unzipping ...
+cd /tmp
+tar xzf "$FILENAME"
+
+echo Loading ...
+cd /var/lib/powerdns
+for file in /tmp/*.dump; do echo $file; mdb_load -f $file -n $(basename $file .dump); done
+
+echo Done

--- a/load.sh
+++ b/load.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+docker-compose -f docker-compose.yml -f docker-compose.dump.yml run lmdb-backup ./load "$1"

--- a/ns/entrypoint.sh
+++ b/ns/entrypoint.sh
@@ -13,4 +13,7 @@ echo mgroup from eth2 group 239.1.2.3 > /etc/smcroute.conf
 # Manage credentials
 envsubst < /etc/powerdns/pdns.conf.var > /etc/powerdns/pdns.conf
 
+# Fix ownership (may be off after importing a backup)
+chown -R pdns:pdns /var/lib/powerdns
+
 exec pdns_server --daemon=no


### PR DESCRIPTION
This PR is based on the 20200218_lmdb branch. It adds a docker-compose override file and a bash script, as well as minor modifications to the replicator, in order to fire up the replicator and its dependencies to create a one-off dump in the `ns` Docker volume, and then exit.

Todo:
- [x] Add tooling to convert the dump to portable text format using [`mdb_dump`](https://www.systutorials.com/docs/linux/man/1-mdb_dump/) / convert back using [`mdb_load`](https://www.systutorials.com/docs/linux/man/1-mdb_load/) (or convince ourselves that we're safe with a binary copy, as long as we stay on x86)
- [ ] Figure out why, when running on the same host as desec-stack, the VPN client can't connect to the VPN server. ([known issue](https://www.reddit.com/r/docker/comments/a2fzxn/openvpn_server_and_client_on_the_same_host/)?)