### PR TITLE
fix(replicator): don't hang when receiving no DNS data

### DIFF
--- a/replicator/run.py
+++ b/replicator/run.py
@@ -48,7 +48,7 @@ def pdns_request(method, *, path, body=None):
 
 def query_serial(zone, server):
     query = dns.message.make_query(zone, 'SOA')
-    response = dns.query.tcp(query, server)
+    response = dns.query.tcp(query, server, timeout=5)
 
     for rrset in response.answer:
         if rrset.rdtype == dns.rdatatype.SOA:


### PR DESCRIPTION
This is a very similar issue to #29, except that it concerns our
DNS SOA query and not the HTTP GET request. The issue is fixed
by introducing a timeout to the dns.query.tcp() call which waits
forever by default if no data arrives for some reason.


The issue had occurred on sao-1.a.desec.io which is why replication wsa unreliable there today (only based on DNS NOTIFYs).

I noticed this on our OpenVPN monitoring dashboard because the VPN client had significatly less traffic than the others. I then obtained the following traceback using `kill -SIGINT` as had proven useful in #29 and also identified the culprit in this case:

```
Apr  8 19:11:00 sao-1 desec-slave/replicator[9997]: Traceback (most recent call last):
Apr  8 19:11:00 sao-1 desec-slave/replicator[9997]:   File "run.py", line 177, in <module>
Apr  8 19:11:00 sao-1 desec-slave/replicator[9997]:     main()
Apr  8 19:11:00 sao-1 desec-slave/replicator[9997]:   File "run.py", line 149, in main
Apr  8 19:11:00 sao-1 desec-slave/replicator[9997]:     catalog_refreshed = catalog.update()
Apr  8 19:11:00 sao-1 desec-slave/replicator[9997]:   File "run.py", line 91, in update
Apr  8 19:11:00 sao-1 desec-slave/replicator[9997]:     if self.age < 60 and self.remote_serial == self.serial:
Apr  8 19:11:00 sao-1 desec-slave/replicator[9997]:   File "run.py", line 69, in remote_serial
Apr  8 19:11:00 sao-1 desec-slave/replicator[9997]:     return query_serial(catalog_domain, master_ip)
Apr  8 19:11:00 sao-1 desec-slave/replicator[9997]:   File "run.py", line 51, in query_serial
Apr  8 19:11:00 sao-1 desec-slave/replicator[9997]:     response = dns.query.tcp(query, server)
Apr  8 19:11:00 sao-1 desec-slave/replicator[9997]:   File "/usr/local/lib/python3.8/site-packages/dns/query.py", line 490, in tcp
Apr  8 19:11:00 sao-1 desec-slave/replicator[9997]:     (r, received_time) = receive_tcp(s, expiration, one_rr_per_rrset,
Apr  8 19:11:00 sao-1 desec-slave/replicator[9997]:   File "/usr/local/lib/python3.8/site-packages/dns/query.py", line 419, in receive_tcp
Apr  8 19:11:00 sao-1 desec-slave/replicator[9997]:     ldata = _net_read(sock, 2, expiration)
Apr  8 19:11:00 sao-1 desec-slave/replicator[9997]:   File "/usr/local/lib/python3.8/site-packages/dns/query.py", line 346, in _net_read
Apr  8 19:11:00 sao-1 desec-slave/replicator[9997]:     _wait_for_readable(sock, expiration)
Apr  8 19:11:00 sao-1 desec-slave/replicator[9997]:   File "/usr/local/lib/python3.8/site-packages/dns/query.py", line 156, in _wait_for_readable
Apr  8 19:11:00 sao-1 desec-slave/replicator[9997]:     _wait_for(s, True, False, True, expiration)
Apr  8 19:11:00 sao-1 desec-slave/replicator[9997]:   File "/usr/local/lib/python3.8/site-packages/dns/query.py", line 131, in _wait_for
Apr  8 19:11:00 sao-1 desec-slave/replicator[9997]:     if not _polling_backend(fd, readable, writable, error, timeout):
Apr  8 19:11:00 sao-1 desec-slave/replicator[9997]:   File "/usr/local/lib/python3.8/site-packages/dns/query.py", line 92, in _poll_for
Apr  8 19:11:00 sao-1 desec-slave/replicator[9997]:     event_list = pollable.poll()
Apr  8 19:11:00 sao-1 desec-slave/replicator[9997]: KeyboardInterrupt

```