### PR TITLE
feat(ns): use default lmdb-sync-mode

### DIFF
--- a/ns/conf/pdns.conf.var
+++ b/ns/conf/pdns.conf.var
@@ -13,4 +13,3 @@ carbon-ourname=${DESEC_NS_CARBONOURNAME}
 
 launch=lmdb
 lmdb-filename=/var/lib/powerdns/pdns.lmdb
-lmdb-sync-mode=nometasync


### PR DESCRIPTION
After discussion with @RobinGeuze, the performance gain of the setting
turns out very small, but the option is not well-tested and potentially
may be the root of other problems.