### PR TITLE
Have the replicator only care about zones with 'Slave' status

### DIFF
--- a/ns/signaling_domain_zone.sh
+++ b/ns/signaling_domain_zone.sh
@@ -7,7 +7,9 @@ pdnsutil create-zone "$SIGNALING_DOMAIN" || exit  # quit if zone exists
 pdnsutil replace-rrset "$SIGNALING_DOMAIN" "@" SOA \
     "${DESEC_NS_SIGNALING_DOMAIN_SOA_MNAME}. ${DESEC_NS_SIGNALING_DOMAIN_SOA_RNAME}. 0 86400 3600 2419200 3600"
 pdnsutil import-zone-key "$SIGNALING_DOMAIN" <(base64 -d <<< "$DESEC_NS_SIGNALING_DOMAIN_ZONE_PRIVATE_KEY_B64")
-pdnsutil increase-serial "$SIGNALING_DOMAIN"
+pdnsutil unset-presigned "$SIGNALING_DOMAIN"
+pdnsutil unset-nsec3 "$SIGNALING_DOMAIN"
+pdnsutil rectify-zone "$SIGNALING_DOMAIN"
 
 # Insert LUA records
 function lua {

--- a/ns/signaling_domain_zone.sh
+++ b/ns/signaling_domain_zone.sh
@@ -6,6 +6,7 @@ SIGNALING_DOMAIN="_signal.$DESEC_NS_NAME"
 pdnsutil create-zone "$SIGNALING_DOMAIN" || exit  # quit if zone exists
 pdnsutil replace-rrset "$SIGNALING_DOMAIN" "@" SOA \
     "${DESEC_NS_SIGNALING_DOMAIN_SOA_MNAME}. ${DESEC_NS_SIGNALING_DOMAIN_SOA_RNAME}. 0 86400 3600 2419200 3600"
+pdnsutil replace-rrset "$SIGNALING_DOMAIN" "@" NS 3600 "$DESEC_NS_NAME"
 pdnsutil import-zone-key "$SIGNALING_DOMAIN" <(base64 -d <<< "$DESEC_NS_SIGNALING_DOMAIN_ZONE_PRIVATE_KEY_B64")
 pdnsutil unset-presigned "$SIGNALING_DOMAIN"
 pdnsutil unset-nsec3 "$SIGNALING_DOMAIN"

--- a/replicator/run.py
+++ b/replicator/run.py
@@ -96,7 +96,11 @@ class Catalog:
 
     def perform_full_zone_sync(self):
         remote_zones = set(self.serials.keys())
-        local_serials = {zone['name']: zone['edited_serial'] for zone in pdns_request('get', path='/zones').json()}
+        local_serials = {
+            zone['name']: zone['edited_serial']
+            for zone in pdns_request('get', path='/zones').json()
+            if zone['kind'] == 'Slave'  # we only care about zones with 'Slave' status
+        }
         local_zones = set(local_serials.keys())
 
         # Compute changes


### PR DESCRIPTION
Without this fix, replicator quickly deletes the zone for the Signaling Domain that is created upon ns startup. :nerd_face: 