### PR TITLE
Adds DNS-over-QUIC Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 .env
 .idea/
-certs/

--- a/certs/entrypoint.sh
+++ b/certs/entrypoint.sh
@@ -4,13 +4,11 @@ openssl req \
     -new \
     -newkey ec:<(openssl ecparam -name prime256v1) \
     -nodes \
-    -keyout /etc/dnsdist/dot.key \
+    -keyout /etc/certs/dox.key \
     -x509 \
     -days 3650 \
-    -out /etc/dnsdist/dot.cer \
+    -out /etc/certs/dox.cer \
     -subj "/C=DE/ST=Berlin/L=Berlin/O=deSEC/OU=autocert/CN=$DESEC_NS_NAME" \
     -addext "subjectAltName = DNS:$DESEC_NS_NAME"
 
-chmod 600 /etc/dnsdist/dot.key
-
-exec dnsdist --supervised
+chmod -R go-rwx /etc/certs

--- a/dnsdist/Dockerfile
+++ b/dnsdist/Dockerfile
@@ -24,6 +24,5 @@ RUN set -ex \
 
 RUN rm -rf /etc/dnsdist/
 COPY conf/ /etc/dnsdist/
-COPY entrypoint.sh /usr/local/bin/
 
-CMD ["entrypoint.sh"]
+CMD ["dnsdist", "--supervised"]

--- a/dnsdist/conf/dnsdist.conf
+++ b/dnsdist/conf/dnsdist.conf
@@ -32,7 +32,7 @@ setWebserverConfig({
 carbonServer(os.getenv('DESEC_NS_CARBONSERVER'), os.getenv('DESEC_NS_CARBONOURNAME'))
 
 -- DoT
-addTLSLocal('0.0.0.0', '/etc/dnsdist/dot.cer', '/etc/dnsdist/dot.key')
+addTLSLocal('0.0.0.0', '/etc/dnsdist/certs/dox.cer', '/etc/dnsdist/certs/dox.key')
 
 -- cache
 pc = newPacketCache(100000, {

--- a/dnsproxy/Dockerfile
+++ b/dnsproxy/Dockerfile
@@ -1,0 +1,13 @@
+FROM golang:bullseye
+
+RUN git clone https://github.com/AdguardTeam/dnsproxy.git
+WORKDIR dnsproxy
+RUN git checkout v0.43.1
+RUN go build -mod=vendor
+
+CMD ./dnsproxy -l 0.0.0.0 \
+    --quic-port=853 \
+    --tls-crt=/etc/dnsproxy/certs/dox.cer \
+    --tls-key=/etc/dnsproxy/certs/dox.key \
+    -u dnsdist:53 \
+    -p 0 \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,6 +73,26 @@ services:
         tag: "desec-ns/dnsdist"
     restart: unless-stopped
 
+  dnsproxy:
+    build: dnsproxy
+    image: ${DOCKER_REGISTRY}desec/desec-ns-dnsproxy:latest
+    init: true
+    depends_on:
+    - dnsdist
+    ports:
+    - "${DESEC_NS_PUBLIC_PORT_DOT:-853}:853/udp"
+    volumes:
+    - certs:/etc/dnsproxy/certs/
+    networks:
+      front:
+        ipv4_address: 10.16.0.3
+      middle:
+    logging:
+      driver: "syslog"
+      options:
+        tag: "desec-ns/dnsproxy"
+    restart: unless-stopped
+
   openvpn-client:
     build: openvpn-client
     image: desec/openvpn-client:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,16 @@
 version: '2.2'
 
 services:
+  certs:
+    image: nginx
+    environment:
+      - DESEC_NS_NAME
+    volumes:
+      - certs:/etc/certs
+      - ./certs/entrypoint.sh:/usr/local/bin/entrypoint.sh
+    command: entrypoint.sh
+    restart: 'no'
+
   ns:
     build: ns
     image: ${DOCKER_REGISTRY}desec/desec-ns:latest
@@ -38,6 +48,7 @@ services:
     init: true
     depends_on:
     - ns
+    - certs
     ports:
     - "${DESEC_NS_PUBLIC_PORT:-53}:53"
     - "${DESEC_NS_PUBLIC_PORT:-53}:53/udp"
@@ -46,6 +57,8 @@ services:
     - DESEC_NS_CARBONSERVER
     - DESEC_NS_CARBONOURNAME
     - DESEC_NS_NAME
+    volumes:
+    - certs:/etc/dnsdist/certs
     networks:
       front:
         ipv4_address: 10.16.0.2
@@ -139,6 +152,7 @@ volumes:
   ns:
   prometheus:
   openvpn-client_logs:
+  certs:
 
 networks:
   # Note that it is required that the front network ranks lower (in lexical order by

--- a/dump.sh
+++ b/dump.sh
@@ -3,3 +3,4 @@ docker-compose -f docker-compose.yml -f docker-compose.dump.yml up replicator  #
 docker-compose -f docker-compose.yml -f docker-compose.dump.yml down  # exits other containers as well
 docker-compose -f docker-compose.yml -f docker-compose.dump.yml pull lmdb-backup
 docker-compose -f docker-compose.yml -f docker-compose.dump.yml run lmdb-backup ./dump
+docker-compose -f docker-compose.yml -f docker-compose.dump.yml down

--- a/kdig-doq.sh
+++ b/kdig-doq.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+
+docker run -t --network "$(docker network ls | grep -oE 'desec-?ns_front')" cznic/knot:master \
+  kdig +quic @dnsproxy "$@"


### PR DESCRIPTION
This uses [AdGuard's dnsproxy](https://github.com/AdguardTeam/dnsproxy/tree/v0.43.1) to offer DNS-over-QUIC. The last commit adds most recent `kdig` to send queries for testing (replace the host name with your `_signal.$DESEC_NS_NAME`):

    docker-compose run kdig kdig @dnsproxy +quic _signal.ns.example.dedyn.io SOA

I'm concerned that there are trouble with IPv6 (see docker-compose.yml network config). However, on my host, both of the following command work:

    docker-compose run kdig kdig @dnsproxy +quic _signal.ns.example.dedyn.io SOA -4
    docker-compose run kdig kdig @dnsproxy +quic _signal.ns.example.dedyn.io SOA -6

This probably does not have outstanding performance (notice that queries will be forwarded to dnsdist and so forth), but as [dnsdist will be adding QUIC support soon](https://github.com/PowerDNS/pdns/issues/9897), it seems not worth putting more effort into this.

Thanks to @ameshkov for this talk at OARC 38 which motivated this PR.

To run QUIC queries against remove servers, the following command can be used:

    docker run --rm cznic/knot:master kdig @dns-unfiltered.adguard.com knot-dns.cz +quic
