### PR TITLE
fix(dnsproxy): use Go 1.18 (quic-go is incompatible with 1.19)

### DIFF
--- a/dnsproxy/Dockerfile
+++ b/dnsproxy/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:bullseye
+FROM golang:1.18-bullseye
 
 RUN git clone https://github.com/AdguardTeam/dnsproxy.git
 WORKDIR dnsproxy


### PR DESCRIPTION
I realized that the build is broken only after merging #50 :-(