### PR TITLE
Use Gentoo-Based pdns

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,6 +74,7 @@ jobs:
         ln -s ../desec-ns/ns
         ln -s ../desec-ns/openvpn-client
         ln -s ../desec-ns/replicator
+        ln -s ../desec-ns/dnsperf
       working-directory: ./desec-stack
 
     - name: Create necessary symlinks in desec-ns  # desec-ns is working dir for vpn-setup below

--- a/dnsdist/Dockerfile
+++ b/dnsdist/Dockerfile
@@ -18,7 +18,7 @@ RUN echo 'deb [arch=amd64] http://repo.powerdns.com/debian bullseye-dnsdist-17 m
 RUN set -ex \
 	&& curl https://repo.powerdns.com/FD380FBB-pub.asc | apt-key add - \
 	&& apt-get update \
-	&& apt-get install -y dnsdist iptables \
+	&& apt-get install -y dnsdist \
 	&& apt-get clean \
 	&& rm -rf /var/lib/apt/lists/*
 

--- a/dnsdist/conf/dnsdist.conf
+++ b/dnsdist/conf/dnsdist.conf
@@ -30,8 +30,12 @@ setWebserverConfig({
 carbonServer(os.getenv('DESEC_NS_CARBONSERVER'), os.getenv('DESEC_NS_CARBONOURNAME'))
 
 -- DoT
-addTLSLocal('0.0.0.0:853', '/etc/dnsdist/certs/dox.cer', '/etc/dnsdist/certs/dox.key')
-addTLSLocal('[::]:853', '/etc/dnsdist/certs/dox.cer', '/etc/dnsdist/certs/dox.key')
+addTLSLocal('0.0.0.0:853', '/etc/dnsdist/certs/dox.cer', '/etc/dnsdist/certs/dox.key', {
+    reusePort=true,
+})
+addTLSLocal('[::]:853', '/etc/dnsdist/certs/dox.cer', '/etc/dnsdist/certs/dox.key', {
+    reusePort=true,
+})
 
 -- cache
 pc = newPacketCache(100000, {

--- a/dnsdist/conf/dnsdist.conf
+++ b/dnsdist/conf/dnsdist.conf
@@ -34,8 +34,8 @@ setWebserverConfig({
 carbonServer(os.getenv('DESEC_NS_CARBONSERVER'), os.getenv('DESEC_NS_CARBONOURNAME'))
 
 -- DoT
-addTLSLocal('0.0.0.0', '/etc/dnsdist/certs/dox.cer', '/etc/dnsdist/certs/dox.key')
-addTLSLocal('[::]', '/etc/dnsdist/certs/dox.cer', '/etc/dnsdist/certs/dox.key')
+addTLSLocal('0.0.0.0:853', '/etc/dnsdist/certs/dox.cer', '/etc/dnsdist/certs/dox.key')
+addTLSLocal('[::]:853', '/etc/dnsdist/certs/dox.cer', '/etc/dnsdist/certs/dox.key')
 
 -- cache
 pc = newPacketCache(100000, {

--- a/dnsdist/conf/dnsdist.conf
+++ b/dnsdist/conf/dnsdist.conf
@@ -5,7 +5,9 @@ addLocal("[::]:53")
 -- allow access from everywhere
 setACL({"0.0.0.0/0", "::/0"})
 
--- for CLI 
+-- for CLI
+-- ACL IP is this container and for some reason used for the connection
+addConsoleACL('10.16.0.2')
 setKey("+256+bit+key+required+even+for+local+access=")
 controlSocket('127.0.0.1')
 

--- a/dnsdist/conf/dnsdist.conf
+++ b/dnsdist/conf/dnsdist.conf
@@ -1,7 +1,3 @@
--- listen
-setLocal("0.0.0.0:53")
-addLocal("[::]:53")
-
 -- allow access from everywhere
 setACL({"0.0.0.0/0", "::/0"})
 

--- a/dnsdist/entrypoint.sh
+++ b/dnsdist/entrypoint.sh
@@ -1,6 +1,3 @@
 #!/usr/bin/env bash
 
-iptables -t nat -A PREROUTING -p udp --dport 853 -j DNAT --to-destination 10.16.5.3:853
-iptables -t nat -A POSTROUTING -j MASQUERADE
-
 exec dnsdist --supervised

--- a/dnsperf/Dockerfile
+++ b/dnsperf/Dockerfile
@@ -1,0 +1,16 @@
+ARG DOCKER_REGISTRY
+FROM ${DOCKER_REGISTRY}ubuntu:bionic
+
+RUN apt-get update && apt-get install -y
+
+RUN apt-get update \
+	&& apt-get install -y build-essential git libssl-dev libldns-dev libck-dev libnghttp2-dev autoconf automake libtool pkg-config man \
+	&& apt-get clean \
+	&& rm -rf /var/lib/apt/lists/*
+
+RUN git clone https://github.com/DNS-OARC/dnsperf.git \
+    && cd dnsperf \
+    && ./autogen.sh \
+    && ./configure \
+    && make \
+    && make install

--- a/dnsproxy/Dockerfile
+++ b/dnsproxy/Dockerfile
@@ -9,5 +9,5 @@ CMD ./dnsproxy -l 0.0.0.0 \
     --quic-port=853 \
     --tls-crt=/etc/dnsproxy/certs/dox.cer \
     --tls-key=/etc/dnsproxy/certs/dox.key \
-    -u dnsdist:53 \
+    -u ns:53 \
     -p 0 \

--- a/docker-compose.connect-stack.yml
+++ b/docker-compose.connect-stack.yml
@@ -15,9 +15,9 @@ services:
       - DESEC_NS_E2E2=1
   test-e2e2:
     environment:
-      - DESECSTACK_E2E2_SECONDARY_NS=10.16.0.2
+      - DESECSTACK_E2E2_SECONDARY_NS=10.16.0.3
     depends_on:
-      - dnsdist
+      - ns
       - replicator
       - openvpn-server
     networks:

--- a/docker-compose.dump.yml
+++ b/docker-compose.dump.yml
@@ -1,4 +1,4 @@
-version: '2.2'
+version: '2.3'
 
 # mostly extending from main .yml
 services:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,6 @@ services:
     networks:
       nsmiddle:
         ipv4_address: 10.16.2.2
-      nsrear:
       nsrearreplication:
         ipv4_address: 10.16.3.3
     sysctls:
@@ -59,7 +58,6 @@ services:
     environment:
     - DESEC_NS_CARBONSERVER
     - DESEC_NS_CARBONOURNAME
-    - DESEC_NS_NAME
     volumes:
     - dox-certs:/etc/dnsdist/certs
     networks:
@@ -195,13 +193,6 @@ networks:
       config:
       - subnet: 10.16.2.0/24
         gateway: 10.16.2.1
-  nsrear:
-    driver: bridge
-    ipam:
-      driver: default
-      config:
-      - subnet: 10.16.1.0/24
-        gateway: 10.16.1.1
   nsrearreplication:
     driver: bridge
     ipam:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,10 @@ services:
     init: true
     cap_add:
     - NET_ADMIN
+    ports:
+    - "${DESEC_NS_PUBLIC_PORT:-53}:53"
+    - "${DESEC_NS_PUBLIC_PORT:-53}:53/udp"
+    - "0.0.0.0:${DESEC_NS_PUBLIC_PORT_DOT:-853}:853/udp"
     environment:
     - DESEC_NS_CARBONSERVER
     - DESEC_NS_CARBONOURNAME
@@ -27,10 +31,15 @@ services:
     - DESEC_NS_SIGNALING_DOMAIN_SOA_RNAME
     - DESEC_NS_COOKIES_SECRET
     networks:
+      nsfront:
+        ipv4_address: 10.16.0.3
+        ipv6_address: ${DESEC_NS_IPV6_ADDRESS}
       nsmiddle:
         ipv4_address: 10.16.2.2
       nsrearreplication:
         ipv4_address: 10.16.3.3
+      nsreardoq:
+        ipv4_address: 10.16.5.2
     sysctls:
       net.ipv4.icmp_echo_ignore_broadcasts: 0
     volumes:
@@ -51,23 +60,15 @@ services:
     cap_add:
     - NET_ADMIN
     ports:
-    - "${DESEC_NS_PUBLIC_PORT:-53}:53"
-    - "${DESEC_NS_PUBLIC_PORT:-53}:53/udp"
     - "${DESEC_NS_PUBLIC_PORT_DOT:-853}:853/tcp"
-    - "0.0.0.0:${DESEC_NS_PUBLIC_PORT_DOT:-853}:853/udp"
     environment:
     - DESEC_NS_CARBONSERVER
     - DESEC_NS_CARBONOURNAME
     volumes:
     - dox-certs:/etc/dnsdist/certs
     networks:
-      nsfront:
-        ipv4_address: 10.16.0.2
-        ipv6_address: ${DESEC_NS_IPV6_ADDRESS}
       nsmiddle:
         ipv4_address: 10.16.2.3
-      nsreardnsdist_dnsproxy:
-        ipv4_address: 10.16.5.2
       nsrearmonitoring_dnsdist:
         ipv4_address: 10.16.4.10
     logging:
@@ -85,7 +86,7 @@ services:
     volumes:
     - dox-certs:/etc/dnsproxy/certs/
     networks:
-      nsreardnsdist_dnsproxy:
+      nsreardoq:
         ipv4_address: 10.16.5.3
     logging:
       driver: "syslog"
@@ -214,7 +215,7 @@ networks:
         config:
         - subnet: 10.16.4.8/29
           gateway: 10.16.4.9
-  nsreardnsdist_dnsproxy:
+  nsreardoq:
       driver: bridge
       ipam:
         driver: default

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -169,6 +169,13 @@ services:
         tag: "desec-ns/prometheus"
     restart: unless-stopped
 
+  dnsperf:
+    build: dnsperf
+    networks:
+      nsfront:
+        ipv4_address: 10.16.0.200
+
+
 volumes:
   ns:
   prometheus:

--- a/ns/Dockerfile
+++ b/ns/Dockerfile
@@ -23,6 +23,8 @@ RUN set -ex \
 	&& apt-get -y install gettext-base \
 	# VPN route
 	&& apt-get -y install iproute2 \
+	# DoX routing
+	&& apt-get -y install iptables \
 	# cleanup
 	&& apt-get clean \
 	&& rm -rf /var/lib/apt/lists/*

--- a/ns/Dockerfile
+++ b/ns/Dockerfile
@@ -1,33 +1,18 @@
 ARG DOCKER_REGISTRY
-FROM ${DOCKER_REGISTRY}ubuntu:bionic
+FROM ${DOCKER_REGISTRY}gentoo/portage:latest as portage
+FROM ${DOCKER_REGISTRY}gentoo/stage3:amd64-systemd
 
-RUN set -ex \
-	# Prepare for adding repository
-	&& apt-get update \
-	&& apt-get install -y curl gnupg smcroute
+# based on stage3 image
+FROM gentoo/stage3:latest
 
-RUN echo 'deb [arch=amd64] http://repo.powerdns.com/ubuntu bionic-auth-46 main' \
-      >> /etc/apt/sources.list \
- && echo 'Package: pdns-*' \
-      > /etc/apt/preferences.d/pdns \
- && echo 'Pin: origin repo.powerdns.com' \
-      >> /etc/apt/preferences.d/pdns \
- && echo 'Pin-Priority: 600' \
-      >> /etc/apt/preferences.d/pdns
+# copy the entire portage volume in
+COPY --from=portage /var/db/repos/gentoo /var/db/repos/gentoo
 
-RUN set -ex \
-	&& curl https://repo.powerdns.com/FD380FBB-pub.asc | apt-key add - \
-	&& apt-get update \
-	&& apt-get install -y pdns-server pdns-backend-lmdb \
-	# credentials management via envsubst
-	&& apt-get -y install gettext-base \
-	# VPN route
-	&& apt-get -y install iproute2 \
-	# DoX routing
-	&& apt-get -y install iptables \
-	# cleanup
-	&& apt-get clean \
-	&& rm -rf /var/lib/apt/lists/*
+# configure portage
+COPY portage/* /etc/portage/
+
+RUN emerge mrouted iproute2 iptables
+RUN emerge -uDt pdns
 
 RUN rm -rf /etc/powerdns/
 COPY conf/ /etc/powerdns/

--- a/ns/conf/pdns.conf.var
+++ b/ns/conf/pdns.conf.var
@@ -1,6 +1,7 @@
 loglevel=5
 api=yes
 api-key=${DESEC_NS_APIKEY}
+cache-ttl=0  # as advised in https://doc.powerdns.com/authoritative/performance.html#packet-cache
 distributor-threads=1  # LMDB does not need several
 dname-processing=yes
 receiver-threads=${_NPROC}

--- a/ns/conf/pdns.conf.var
+++ b/ns/conf/pdns.conf.var
@@ -2,6 +2,7 @@ loglevel=5
 api=yes
 api-key=${DESEC_NS_APIKEY}
 dname-processing=yes
+reuseport=yes
 setgid=pdns
 setuid=pdns
 secondary=yes

--- a/ns/conf/pdns.conf.var
+++ b/ns/conf/pdns.conf.var
@@ -1,6 +1,7 @@
 loglevel=5
 api=yes
 api-key=${DESEC_NS_APIKEY}
+distributor-threads=1  # LMDB does not need several
 dname-processing=yes
 receiver-threads=${_NPROC}
 reuseport=yes

--- a/ns/conf/pdns.conf.var
+++ b/ns/conf/pdns.conf.var
@@ -2,6 +2,7 @@ loglevel=5
 api=yes
 api-key=${DESEC_NS_APIKEY}
 dname-processing=yes
+receiver-threads=${_NPROC}
 reuseport=yes
 setgid=pdns
 setuid=pdns

--- a/ns/entrypoint.sh
+++ b/ns/entrypoint.sh
@@ -10,7 +10,8 @@
 echo mgroup from eth2 group 239.1.2.3 > /etc/smcroute.conf
 /usr/sbin/smcroute -d
 
-# Manage credentials
+# Render configuration
+export _NPROC=$(nproc)
 envsubst < /etc/powerdns/pdns.conf.var > /etc/powerdns/pdns.conf
 
 # Fix ownership (may be off after importing a backup)

--- a/ns/entrypoint.sh
+++ b/ns/entrypoint.sh
@@ -20,5 +20,9 @@ chown -R pdns:pdns /var/lib/powerdns
 [ -n "$DESEC_NS_SIGNALING_DOMAIN_ZONE_PRIVATE_KEY_B64" ] && \
     su pdns -s /bin/bash -c /usr/bin/local/signaling_domain_zone.sh
 
+iptables -t nat -A PREROUTING -p tcp --dport 853 -j DNAT --to-destination 10.16.2.3:853  # dnsdist
+iptables -t nat -A PREROUTING -p udp --dport 853 -j DNAT --to-destination 10.16.5.3:853  # dnsproxy
+iptables -t nat -A POSTROUTING -j MASQUERADE
+
 # Start pdns for production
 exec pdns_server --daemon=no

--- a/ns/entrypoint.sh
+++ b/ns/entrypoint.sh
@@ -2,13 +2,13 @@
 
 # Route required for asking questions into the stack-side network via VPN
 # Ths is assuming that the stack-side network prefix is 172.16
-/sbin/ip route add 172.16.7.0/24 via 10.16.3.2
+ip route add 172.16.7.0/24 via 10.16.3.2
 
 # Route to contact VPN client
-/sbin/ip route add 10.8.0.0/24 via 10.16.3.2
+ip route add 10.8.0.0/24 via 10.16.3.2
 
-echo mgroup from eth2 group 239.1.2.3 > /etc/smcroute.conf
-/usr/sbin/smcroute -d
+echo phyint eth2 static-group 239.1.2.3 > /etc/mrouted.conf
+mrouted
 
 # Render configuration
 export _NPROC=$(nproc)

--- a/ns/portage/make.conf
+++ b/ns/portage/make.conf
@@ -1,0 +1,18 @@
+# These settings were set by the catalyst build script that automatically
+# built this stage.
+# Please consult /usr/share/portage/config/make.conf.example for a more
+# detailed example.
+COMMON_FLAGS="-O3 -pipe -march=sandybridge"
+CFLAGS="${COMMON_FLAGS}"
+CXXFLAGS="${COMMON_FLAGS}"
+FCFLAGS="${COMMON_FLAGS}"
+FFLAGS="${COMMON_FLAGS}"
+
+# NOTE: This stage was built with the bindist Use flag enabled
+
+# This sets the language of build output to English.
+# Please keep this setting intact when reporting bugs.
+LC_MESSAGES=C
+
+# multiprocessing
+MAKEOPTS="--jobs 8 --load-average 9"

--- a/ns/portage/package.license
+++ b/ns/portage/package.license
@@ -1,0 +1,1 @@
+net-misc/mrouted *

--- a/ns/portage/package.use
+++ b/ns/portage/package.use
@@ -1,0 +1,1 @@
+net-dns/pdns lmdb tools lua-records sodium -ldap -mysql -postgres -sqlite -geoip -doc -debug -mydns -remote -tinydns"


### PR DESCRIPTION
Using Gentoo allows customized compiler flags. I've set the optimization to `sandybridge`, which is what is appriopriate for our machines.

This PR also contains performance measurement tools.

- [ ] Check upgrade notes for pdns 4.7
- [ ] Pin version to 4.7
- [ ] do not deploy dnsperf
- [x] make sure it's actually faster :)

@robertbuhren