### PR TITLE
fix(replicator): allow some more time for fetching serial list

### DIFF
--- a/replicator/run.py
+++ b/replicator/run.py
@@ -76,7 +76,7 @@ class Catalog:
         # Throws Timeout exception if nothing is received for `timeout` seconds
         r = requests.get(
             'https://{}/api/v1/serials/'.format(os.environ['DESECSTACK_VPN_SERVER']),
-            timeout=10,
+            timeout=30,
             verify=ssl_verify,
         )
         if r.status_code not in range(200, 300):


### PR DESCRIPTION
The serials list is about 400 KB. Temporary glitches on the network path may require a longer timeout (currently, this is for sin-1.c.desec.io).